### PR TITLE
fix: user not found in session

### DIFF
--- a/x3ddemoweb/src/java/servlet/Login.java
+++ b/x3ddemoweb/src/java/servlet/Login.java
@@ -56,6 +56,7 @@ public class Login extends HttpServlet {
                 if (user != null) {
                         request.getSession().setAttribute("user_id", user.get_user_id());
                         request.getSession().setAttribute("alias", user.get_alias());
+                        request.getSession().setAttribute("user", user);
                         response.sendRedirect("ChatroomLoader");
                 } else {
 			response.sendRedirect("401.jsp");


### PR DESCRIPTION
in `FriendRequest.java` line 72. It tries to get the user from Session, but there is no User object stored in Session, so it always went to Exception.
This PR is a quick fix for this issue.
```
               backend.User user;
               Integer uid;
                Integer target_id;
                try {
			user = (backend.User) request.getSession().getAttribute("user");
                        if (user == null || action == null || target == null) {
                                throw new Exception();
                        }
                        uid = (Integer) request.getSession().getAttribute("user_id");
                        target_id = Integer.parseInt(target);
                } catch (Exception ex) {
                        out.print("Malformed request: " + qs);
                        return ;
                }
```